### PR TITLE
Add link highlighting during mouse drag operation

### DIFF
--- a/simple-extension/content.js
+++ b/simple-extension/content.js
@@ -6,6 +6,7 @@ let isDragging = false;
 let startX = 0;
 let startY = 0;
 let selectionBox = null;
+let highlightedLinks = [];
 
 // Listen for key events
 document.addEventListener('keydown', (e) => {
@@ -21,6 +22,7 @@ document.addEventListener('keyup', (e) => {
     isDragging = false;
     document.body.style.userSelect = '';
     removeSelectionBox();
+    clearHighlightedLinks();
   }
 });
 
@@ -38,6 +40,7 @@ document.addEventListener('mousedown', (e) => {
 document.addEventListener('mousemove', (e) => {
   if (isDragging && selectionBox) {
     updateSelectionBox(startX, startY, e.pageX, e.pageY);
+    highlightLinksInSelection();
     e.preventDefault();
   }
 });
@@ -54,6 +57,7 @@ document.addEventListener('mouseup', (e) => {
     
     isDragging = false;
     removeSelectionBox();
+    clearHighlightedLinks();
     e.preventDefault();
   }
 });
@@ -135,4 +139,54 @@ function getLinksInSelection() {
   }
   
   return links;
+}
+
+function highlightLinksInSelection() {
+  clearHighlightedLinks();
+  
+  if (!selectionBox) return;
+  
+  const rect = selectionBox.getBoundingClientRect();
+  const scrollX = window.pageXOffset;
+  const scrollY = window.pageYOffset;
+  
+  const selectionArea = {
+    left: rect.left + scrollX,
+    top: rect.top + scrollY,
+    right: rect.right + scrollX,
+    bottom: rect.bottom + scrollY
+  };
+  
+  const allLinks = document.querySelectorAll('a[href]');
+  
+  for (const link of allLinks) {
+    const linkRect = link.getBoundingClientRect();
+    const linkArea = {
+      left: linkRect.left + scrollX,
+      top: linkRect.top + scrollY,
+      right: linkRect.right + scrollX,
+      bottom: linkRect.bottom + scrollY
+    };
+    
+    if (linkArea.left < selectionArea.right &&
+        linkArea.right > selectionArea.left &&
+        linkArea.top < selectionArea.bottom &&
+        linkArea.bottom > selectionArea.top) {
+      
+      const href = link.href;
+      if (href && href.startsWith('http')) {
+        link.style.backgroundColor = 'rgba(255, 102, 0, 0.3)';
+        link.style.outline = '2px solid #ff6600';
+        highlightedLinks.push(link);
+      }
+    }
+  }
+}
+
+function clearHighlightedLinks() {
+  for (const link of highlightedLinks) {
+    link.style.backgroundColor = '';
+    link.style.outline = '';
+  }
+  highlightedLinks = [];
 }

--- a/simple-extension/manifest.json
+++ b/simple-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Simple Linkclump",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Hold Z key and drag to open multiple links in new tabs",
   "background": {
     "service_worker": "background.js"

--- a/simple-extension/test.html
+++ b/simple-extension/test.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>LinkClump Test Page</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            line-height: 1.6;
+        }
+        .link-section {
+            margin: 20px 0;
+            padding: 10px;
+            border: 1px solid #ddd;
+        }
+        a {
+            display: inline-block;
+            margin: 5px 10px;
+            padding: 5px 10px;
+            text-decoration: none;
+            color: #0066cc;
+            border: 1px solid #0066cc;
+            border-radius: 3px;
+        }
+        a:hover {
+            background-color: #f0f8ff;
+        }
+    </style>
+</head>
+<body>
+    <h1>LinkClump Extension Test Page</h1>
+    <p>Instructions: Hold Z key and drag to select multiple links. They should highlight in orange during drag.</p>
+    
+    <div class="link-section">
+        <h2>Test Links Section 1</h2>
+        <a href="https://google.com">Google</a>
+        <a href="https://github.com">GitHub</a>
+        <a href="https://stackoverflow.com">Stack Overflow</a>
+        <a href="https://developer.mozilla.org">MDN Web Docs</a>
+    </div>
+    
+    <div class="link-section">
+        <h2>Test Links Section 2</h2>
+        <a href="https://youtube.com">YouTube</a>
+        <a href="https://reddit.com">Reddit</a>
+        <a href="https://wikipedia.org">Wikipedia</a>
+        <a href="https://twitter.com">Twitter</a>
+    </div>
+    
+    <div class="link-section">
+        <h2>Mixed Content</h2>
+        <p>Some text with <a href="https://example.com">inline links</a> and more text.</p>
+        <p>Another paragraph with <a href="https://test.com">another link</a> here.</p>
+        <a href="https://final.com">Final Link</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
- Implement visual feedback for selected links during Z+drag operation
- Links now highlight with orange background and outline while being selected
- Highlighting clears when drag ends or Z key is released
- Add test page for functionality verification
- Bump version to 1.1.0

🤖 Generated with [Claude Code](https://claude.ai/code)